### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Unclutter your terminal using this small, but helpful program. Put the `<hr />` 
 To start using gohr, run `go get`:
 
 ```terminal
-$ go get github.com/hasit/gohr/hr
+$ go get github.com/hasit/gohr/cmd/hr
 ```
 
 This will download and install `gohr` library and `hr` executable.


### PR DESCRIPTION
Running the example in the readme causes an error.

``` sh
❯ go get github.com/hasit/gohr/hr
package github.com/hasit/gohr/hr: cannot find package "github.com/hasit/gohr/hr" in any of:
    /usr/local/Cellar/go/1.6.1/libexec/src/github.com/hasit/gohr/hr (from $GOROOT)
    /Users/Wayne/gocode/src/github.com/hasit/gohr/hr (from $GOPATH)

```

This works:

``` sh
~
❯ go get github.com/hasit/gohr/cmd/hr

~
❯ hr
########################################################################################################################
```
